### PR TITLE
增加未完成任务获取次数

### DIFF
--- a/app/alist_sync.py
+++ b/app/alist_sync.py
@@ -234,11 +234,8 @@ class AlistSync:
         if response and response.get("data", []):
             for item in response["data"]:
                 name = item["name"]
-                try:
-                    result = name.replace("](", "")
-                    name_list.append(result)
-                except IndexError:
-                    print(f"字符串 '{name}' 未找到匹配的切分字符串。")
+                result = name.replace("](", "")
+                name_list.append(result)
         self.task_list = name_list
         return True
         # return name_list

--- a/app/alist_sync.py
+++ b/app/alist_sync.py
@@ -525,6 +525,7 @@ class AlistSync:
                         return True
 
                     # 检查是否在未完成的任务列表中，如果存在，则跳过
+                    self.get_copy_task_undone()
                     for task_item in self.task_list:
                         if src_dir in task_item and dst_dir in task_item and src_path in task_item:
                             logger.info(f"文件【{item_name}】在未完成的任务列表中，跳过复制")


### PR DESCRIPTION
- 移除不必要的异常处理

  `name.replace("](", "")` 只是字符串替换操作，不会抛出 `IndexError`。因此，`try...except IndexError` 是多余的，可以直接移除异常处理。

- 增加未完成任务获取次数

  每次检查是否在未完成的任务列表中时重新请求 `undone` 接口，增加调用次数，避免多个任务同时操作同一目录时出现重复添加。

  Close: https://github.com/xjxjin/alist-sync/issues/43